### PR TITLE
Undefined name: import os for line 75

### DIFF
--- a/cmd2_submenu/submenu.py
+++ b/cmd2_submenu/submenu.py
@@ -1,6 +1,7 @@
 #
 # coding=utf-8
 import copy
+import os
 import readline
 from typing import List
 


### PR DESCRIPTION
__os__ is used on line 75 but it is never defined or imported.  This constitutes an _undefined name_ which has the potential to raise NameError at runtime.